### PR TITLE
Update README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,8 +156,3 @@ These references are useful across all certifications.
 	- Anything that compromises the integrity of the exam.
 - When one of my blog posts leaked some exam info, I was contacted by the Google Certifications Team.
 - If you find any posts that I've listed which might be a concern, please let me and also the original authors know.
-
-### Landing Image
-Just some image so that the photo that shows up in social media is not my face from my github profile.
-
-![Some certification badges](./images/gcp-all-circles@0.5x.jpg)


### PR DESCRIPTION
In order to change the repository's image on social media, it is recommended to change it using settings and not by adding images at the end. Sometimes it may not be rendered on all browsers properly. The social media preview setting is available when we go to the settings for a GitHub repository. We have the option of uploading a (1280×640px image for the preview. 

More information here: https://docs.github.com/en/github/administering-a-repository/customizing-your-repositorys-social-media-preview

The preview image may not work for private repositories