### PR TITLE
add direct link to packt

### DIFF
--- a/professional-cloud-architect.md
+++ b/professional-cloud-architect.md
@@ -38,7 +38,7 @@
 ### Books
 | Published | Title/Link | Author |
 | :---:         |     :---      |          :--- |
-| 2021/12 | [Professional Cloud Architect - Google Cloud Certification Guide - Second Edition](https://learning.oreilly.com/library/view/professional-cloud-architect/9781801812290/) <br> [Direct link to Packt - O'Reilly link broken](https://www.packtpub.com/product/professional-cloud-architect-google-cloud-certification-guide-second-edition/9781801812290/) | Konrad Clapa, Brian Gerrard |
+| 2021/12 | [Professional Cloud Architect - Google Cloud Certification Guide - Second Edition](https://www.packtpub.com/product/professional-cloud-architect-google-cloud-certification-guide-second-edition/9781801812290/) | Konrad Clapa, Brian Gerrard |
 | 2019/11 | [Official Google Cloud Certified Professional Cloud Architect Study Guide](https://www.wiley.com/en-in/Official+Google+Cloud+Certified+Professional+Cloud+Architect+Study+Guide-p-9781119602446) | Dan Sullivan |
 | | [Google Cloud Platform for Architects](https://www.amazon.com/Google-Cloud-Platform-Architects-solutions/dp/1788834305/) | |
 | | [Google Cloud Platform Cookbook](https://www.amazon.com/Google-Cloud-Platform-Cookbook-applications/dp/1788291999/) | |

--- a/professional-cloud-architect.md
+++ b/professional-cloud-architect.md
@@ -38,7 +38,7 @@
 ### Books
 | Published | Title/Link | Author |
 | :---:         |     :---      |          :--- |
-| 2021/12 | [Professional Cloud Architect - Google Cloud Certification Guide - Second Edition](https://learning.oreilly.com/library/view/professional-cloud-architect/9781801812290/) | Konrad Clapa, Brian Gerrard |
+| 2021/12 | [Professional Cloud Architect - Google Cloud Certification Guide - Second Edition](https://learning.oreilly.com/library/view/professional-cloud-architect/9781801812290/) <br> [Direct link to Packt - O'Reilly link broken](https://www.packtpub.com/product/professional-cloud-architect-google-cloud-certification-guide-second-edition/9781801812290/) | Konrad Clapa, Brian Gerrard |
 | 2019/11 | [Official Google Cloud Certified Professional Cloud Architect Study Guide](https://www.wiley.com/en-in/Official+Google+Cloud+Certified+Professional+Cloud+Architect+Study+Guide-p-9781119602446) | Dan Sullivan |
 | | [Google Cloud Platform for Architects](https://www.amazon.com/Google-Cloud-Platform-Architects-solutions/dp/1788834305/) | |
 | | [Google Cloud Platform Cookbook](https://www.amazon.com/Google-Cloud-Platform-Cookbook-applications/dp/1788291999/) | |


### PR DESCRIPTION
Hello, the O'Reilly link is broken - it shows up in search, but the link is broken on their site also..

https://www.oreilly.com/search/?query=Professional%20Cloud%20Architect%20-%20Google%20Cloud%20Certification%20Guide%20-%20Second%20Edition&extended_publisher_data=true&highlight=true&include_assessments=false&include_case_studies=true&include_courses=true&include_playlists=true&include_collections=true&include_notebooks=true&include_sandboxes=true&include_scenarios=true&is_academic_institution_account=false&source=user&sort=relevance&facet_json=true&json_facets=true&page=0&include_facets=true&include_practice_exams=true

Anyway - I added a direct link to Packt

Thanks! Chad